### PR TITLE
feat: healthchecks

### DIFF
--- a/backend/database/redis.js
+++ b/backend/database/redis.js
@@ -119,11 +119,20 @@ async function exec(command) {
   }
 }
 
+function releaseRedisConnection(client) {
+  if (client) {
+    redisPool.release(client).catch((err) => {
+      logger.error(`Error releasing Redis client back to pool: ${err}`);
+    });
+  }
+}
+
 module.exports = {
   setWithExpiry,
   getOrDefault,
   deleteKey,
   setKey,
   exec,
-  getRedisConnection
+  getRedisConnection,
+  releaseRedisConnection
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "nodemon": "^3.1.7",
+        "supertest": "^7.0.0",
         "wait-on": "^8.0.1"
       }
     },
@@ -1929,6 +1930,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2170,6 +2202,16 @@
         "node": ">= 0.6.x"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2231,6 +2273,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2434,6 +2483,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dezalgo/node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2452,6 +2519,21 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -2519,6 +2601,39 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2680,6 +2795,13 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2775,6 +2897,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2846,6 +2983,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2853,6 +3015,20 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2909,6 +3085,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2928,6 +3117,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2938,6 +3140,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -5252,6 +5464,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -5488,6 +5710,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-finished": {
@@ -6160,6 +6395,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6393,6 +6704,95 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "jest": "^29.7.0",
     "nodemon": "^3.1.7",
+    "supertest": "^7.0.0",
     "wait-on": "^8.0.1"
   }
 }

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const router = express.Router();
+const { pingRedis, pingPostgres } = require('../utilities/healthcheck');
+
+router.get('/', async (req, res) => {
+  try {
+    const [redisStatus, postgresStatus] = await Promise.all([
+      pingRedis(),
+      pingPostgres(),
+    ]);
+
+    const statusReport = {
+      status: {
+        redis: {
+          state: redisStatus.state,
+          latency: redisStatus.latency,
+          ...(redisStatus.error && { error: redisStatus.error }),
+        },
+        postgres: {
+          state: postgresStatus.state,
+          latency: postgresStatus.latency,
+          ...(postgresStatus.error && { error: postgresStatus.error }),
+        },
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    const allServicesUp =
+      redisStatus.state === 'UP' && postgresStatus.state === 'UP';
+
+    if (allServicesUp) {
+      return res.status(200).json(statusReport);
+    } else {
+      return res.status(503).json(statusReport);
+    }
+  } catch (error) {
+    return res.status(500).json({
+      status: {
+        error: 'Internal Server Error',
+      },
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
+module.exports = router

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -8,4 +8,5 @@ module.exports = (app) => {
   app.use('/timers', require('./timers'));
   app.use('/auth', require('./auth'));
   app.use('/tags', require('./tags'));
+  app.use('/health', require('./health'));
 };

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,163 @@
+// backend/tests/health.test.js
+
+const request = require('supertest');
+const express = require('express');
+const router = require('../routes/health');
+const { pingRedis, pingPostgres } = require('../utilities/healthcheck');
+
+jest.mock('../utilities/healthcheck', () => ({
+  pingRedis: jest.fn(),
+  pingPostgres: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/health', router);
+
+describe('/health Endpoint', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return 200 OK when all dependencies are healthy', async () => {
+    // Mock healthy responses
+    pingRedis.mockResolvedValue({
+      state: 'UP',
+      latency: '10ms',
+    });
+
+    pingPostgres.mockResolvedValue({
+      state: 'UP',
+      latency: '15ms',
+    });
+
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: {
+        redis: {
+          state: 'UP',
+          latency: '10ms',
+        },
+        postgres: {
+          state: 'UP',
+          latency: '15ms',
+        },
+      },
+      timestamp: expect.any(String),
+    });
+  });
+
+  test('should return 503 Service Unavailable when Redis is down', async () => {
+    // Mock Redis down and Postgres healthy
+    pingRedis.mockResolvedValue({
+      state: 'DOWN',
+      latency: null,
+      error: 'Connection refused',
+    });
+
+    pingPostgres.mockResolvedValue({
+      state: 'UP',
+      latency: '15ms',
+    });
+
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      status: {
+        redis: {
+          state: 'DOWN',
+          latency: null,
+          error: 'Connection refused',
+        },
+        postgres: {
+          state: 'UP',
+          latency: '15ms',
+        },
+      },
+      timestamp: expect.any(String),
+    });
+  });
+
+  test('should return 503 Service Unavailable when Postgres is down', async () => {
+    // Mock Redis healthy and Postgres down
+    pingRedis.mockResolvedValue({
+      state: 'UP',
+      latency: '10ms',
+    });
+
+    pingPostgres.mockResolvedValue({
+      state: 'DOWN',
+      latency: null,
+      error: 'Query failed',
+    });
+
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      status: {
+        redis: {
+          state: 'UP',
+          latency: '10ms',
+        },
+        postgres: {
+          state: 'DOWN',
+          latency: null,
+          error: 'Query failed',
+        },
+      },
+      timestamp: expect.any(String),
+    });
+  });
+
+  test('should return 503 Service Unavailable when both dependencies are down', async () => {
+    // Mock both Redis and Postgres down
+    pingRedis.mockResolvedValue({
+      state: 'DOWN',
+      latency: null,
+      error: 'Connection refused',
+    });
+
+    pingPostgres.mockResolvedValue({
+      state: 'DOWN',
+      latency: null,
+      error: 'Query failed',
+    });
+
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      status: {
+        redis: {
+          state: 'DOWN',
+          latency: null,
+          error: 'Connection refused',
+        },
+        postgres: {
+          state: 'DOWN',
+          latency: null,
+          error: 'Query failed',
+        },
+      },
+      timestamp: expect.any(String),
+    });
+  });
+
+  test('should return 500 Internal Server Error on unexpected errors', async () => {
+    pingRedis.mockRejectedValue(new Error('Unexpected Error'));
+
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      status: {
+        error: 'Internal Server Error',
+      },
+      timestamp: expect.any(String),
+    });
+  });
+});

--- a/backend/utilities/healthcheck.js
+++ b/backend/utilities/healthcheck.js
@@ -1,39 +1,62 @@
 const redis = require('../database/redis');
+const pg = require('../database/postgres');
 const logger = require('./logger');
 
 async function pingRedis() {
-  const client = await redis.getRedisConnection();
-  
   try {
+    const client = await redis.getRedisConnection();
     const startTime = Date.now();
     const result = await client.ping();
     const endTime = Date.now();
     const latency = endTime - startTime;
 
-    if (result !== 'PONG') {
+    if(result !== 'PONG') {
       logger.error(`Unexpected response from Redis: ${result}`);
+      return {
+        state: 'DOWN',
+        latency: null,
+        error: 'Unexpected PING response',
+      };
     }
 
-    const info = await client.info();
-    const memoryUsage = info.split('\n').find(line => line.startsWith('used_memory_human:'));
-    const connectedClients = info.split('\n').find(line => line.startsWith('connected_clients:'));
-
     return {
-      status: 'healthy',
+      state: 'UP',
       latency: `${latency}ms`,
-      memoryUsage: memoryUsage ? memoryUsage.split(':')[1].trim() : 'Unknown',
-      connectedClients: connectedClients ? connectedClients.split(':')[1].trim() : 'Unknown'
     };
   } catch (error) {
-    logger.error(`Redis ping failed: ${error}`);
+    logger.error(`Redis health check failed: ${error.message}`);
     return {
-      status: 'unhealthy',
-      error: error.message
+      state: 'DOWN',
+      latency: null,
+      error: error.message,
+    };
+  } finally {
+    redis.releaseRedisConnection();
+  }
+}
+
+async function pingPostgres() {
+  try {
+    const startTime = Date.now();
+    await pg.executeQuery('SELECT 1');
+    const endTime = Date.now();
+    const latency = endTime - startTime;
+
+    return {
+      state: 'UP',
+      latency: `${latency}ms`,
+    };
+  } catch(error) {
+    logger.error(`Postgres health check failed: ${error.message}`);
+    return {
+      state: 'DOWN',
+      latency: null,
+      error: error.message,
     };
   }
 }
 
 module.exports = {
   pingRedis,
-};
-
+  pingPostgres,
+}

--- a/infra/posting/health/health.posting.yaml
+++ b/infra/posting/health/health.posting.yaml
@@ -1,0 +1,2 @@
+name: health
+url: http://localhost:8080/health


### PR DESCRIPTION
## Description
Implement a /health endpoint to monitor the health and latency of the backend service and its dependencies (Redis and Postgres + any future service added as part of a microservices setup)

## Related Issue(s)
Closes #38 

## Changes Made
- Added a new route `backend/routes/health.js` to handle health check requests
- Extended `backend/utilities/healthcheck.js` with functions pingRedis and pingPostgres to assess the health of Redis and Postgres
- Unit tests in `backend/tests/health.test.js` using Jest and Supertest

## Type of Change
- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📄 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🛠 Maintenance
- [ ] 🔒 Security fix

## Checklist
- [x] I have tested the changes locally.
- [x] I have assigned reviewers for this PR.

## Screenshots (if applicable)
Example response:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/d0d97bf4-dd18-4836-be8f-c66bc43e70f9" />

Unit tests:
<img width="708" alt="image" src="https://github.com/user-attachments/assets/4c6aec78-8110-44cb-a534-1c6840d865e9" />


## Additional Notes
Can be easily extended/configured on prod launch when we use Cloud SQL / Memorystore 
